### PR TITLE
[SERV-12] Always use UTF-8 to process XML files harvested via OAI-PMH

### DIFF
--- a/pacific_rim_library/indexer.py
+++ b/pacific_rim_library/indexer.py
@@ -236,7 +236,7 @@ class Indexer(object):
             record_sets_serialized_encoded = self.record_sets.get(record_identifier.encode())
 
             # Generate a Solr document from the metadata record.
-            with open(path, 'r') as record_file:
+            with open(path, 'r', encoding='utf-8') as record_file:
                 prl_solr_document = self.get_solr_document(record_file)
 
             # If there is a thumbnail, save it to the system.

--- a/pacific_rim_library/prl_solr_document.py
+++ b/pacific_rim_library/prl_solr_document.py
@@ -35,7 +35,7 @@ class PRLSolrDocument:
         self.s3_host = s3_host
         self.original_thumbnail_metadata_prop = None
 
-        self.soup = BeautifulSoup(file_object, 'lxml-xml')
+        self.soup = BeautifulSoup(file_object, 'lxml-xml', from_encoding='utf-8')
         self.id = identifier
         self.pysolr_doc = {}
         self.pysolr_doc.update({


### PR DESCRIPTION
- explicitly require harvested records to be processed as UTF-8 (per the [OAI-PMH spec](https://www.openarchives.org/OAI/openarchivesprotocol.html#XMLResponse)) rather than a platform-dependent default encoding that is [chosen](https://docs.python.org/3.6/library/functions.html#open) (and apparently also [guessed](https://www.crummy.com/software/BeautifulSoup/bs4/doc/#encodings)) at runtime