### PR TITLE
[SERV-301] Enable configuration of Solr core name

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,9 @@ SOLR_HOST=
 # NOTE: port 80 must still be specified due to a limitation of Docker Compose profiles.
 SOLR_PORT=
 
+# The name of the Solr core.
+SOLR_CORE_NAME=
+
 # The number of seconds to try pinging Solr for, after which the indexer service will not be started.
 # Set to 0 to try forever.
 SOLR_PING_TIMEOUT=

--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ On delete events, it removes any traces of the record represented by the deleted
 1. Create a local `prl-solr` Docker image:
 
     1. Create a local `solr4` Docker image by following the instructions at https://github.com/docker-solr/docker-solr4 (you must be authenticated to hub.docker.com)
-    1. Clone https://github.com/UCLALibrary/prrla-solr-conf and then run something like:
+    1. Clone https://github.com/UCLALibrary/prrla-solr-conf and then run something like this (note that the value of the `CORE_NAME` build arg must match the value of `SOLR_CORE_NAME` specified in `.env`):
 
         ```bash
-        $ docker image build . --tag prl-solr:latest
+        $ docker image build --build-arg CORE_NAME=prl . --tag prl-solr:latest
         ```
 
 1. Create a local jOAI Docker image per the instructions [here](https://github.com/NCAR/joai-project/blob/25c00ccc7d63c2c3a3c673a321be6a21bc474b78/web/docs/DOCKER_BUILD.md).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       - LEVELDB_RECORD_SETS_DIRECTORY
       - SOLR_HOST
       - SOLR_PORT
+      - SOLR_CORE_NAME
       - SOLR_PING_TIMEOUT
       - THUMBNAILS_DIRECTORY
     volumes:

--- a/pacific_rim_library/indexer.py
+++ b/pacific_rim_library/indexer.py
@@ -81,7 +81,11 @@ class Indexer(object):
         """Initializes the interfaces for all third-party services NOT instantiated by this module."""
 
         try:
-            solr_base_url = 'http://{}:{}/solr/prl'.format(os.environ.get('SOLR_HOST'), os.environ.get('SOLR_PORT'))
+            solr_base_url = 'http://{}:{}/solr/{}'.format(
+                os.environ.get('SOLR_HOST'),
+                os.environ.get('SOLR_PORT'),
+                os.environ.get('SOLR_CORE_NAME')
+            )
 
             # Make sure we can connect to Solr.
             def solr_ping(base_url):

--- a/wait-for-solr.sh
+++ b/wait-for-solr.sh
@@ -17,7 +17,7 @@ fi
 
 SECONDS=0
 
-until curl -s "http://${SOLR_HOST}:${SOLR_PORT}/solr/prl/admin/ping"; do
+until curl -s "http://${SOLR_HOST}:${SOLR_PORT}/solr/${SOLR_CORE_NAME}/admin/ping"; do
 
     if [[ ${SOLR_PING_TIMEOUT} -gt 0 && ${SECONDS} -ge ${SOLR_PING_TIMEOUT} ]]
     then


### PR DESCRIPTION
I will link to a supporting PR for https://github.com/UCLALibrary/prrla-solr-conf (adding the new build arg) once my push access to that repository is restored.